### PR TITLE
add window span size options to shuffler_nogui

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ Shuffler can also be used by cli. To use, run `shuffler_nogui` with as arguments
 
 will place the active window in the bottom left cell in a grid of 2 x 2.
 
+To make the window span multiple cells two extra arguments can be provided, for example:
+
+`shuffler_nogui 3 3 1 1 2 2`
+
+will place the active window at the bottom right hand corner of a 3 x 3 grid spanning 2 columns and rows.

--- a/shuffler_nogui
+++ b/shuffler_nogui
@@ -25,8 +25,8 @@ program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-def move_win(row, col, playfield):
-    totalspan = [[row, col], [row, col]]
+def move_win(col, row, playfield):
+    totalspan = [[col, row], [col+xsize-1, row+ysize-1]]
     y_offs = st.get_yshift(curr_subject)
     trg = st.windowtarget(
         totalspan, xycoords[0], xycoords[1], playfield, y_offs,
@@ -48,7 +48,7 @@ def toggle_max():
         curr_subject.maximize()
 
 
-def move_window(row, col):
+def move_window(col, row):
     win_geodata = geo.get_windows_oncurrent(screendata)
     wins = win_geodata["windows"]
     playfield = st.calc_playfield(win_geodata)
@@ -57,7 +57,7 @@ def move_window(row, col):
             curr_subject in wins,
             st.check_windowtype(curr_subject),
         ]):
-            move_win(row, col, playfield)
+            move_win(col, row, playfield)
     except AttributeError:
         pass
 
@@ -76,6 +76,15 @@ elif shuffler_args[:2] == ["1", "1"]:
     toggle_max()
 else:
     xmatrix, ymatrix, xpos, ypos = [int(shuffler_args[n]) for n in range(0, 4)]
+    if len(shuffler_args) == 6:
+        xsize, ysize = [int(shuffler_args[n]) for n in range(4, 6)]
+        if xsize > xmatrix - xpos: xsize = xmatrix - xpos
+        elif xsize < 1: xsize = 1
+        if ysize > ymatrix - ypos: ysize = ymatrix - ypos
+        elif ysize < 1: ysize = 1
+    else:
+        xsize, ysize = 1, 1
+
     # Wnck
     screendata = Wnck.Screen.get_default()
     screendata.force_update()


### PR DESCRIPTION
Hi, 
I prefer binding shortcuts over using the gui app, but the option to make a window span multiple cells (which is possible through the GUI) was missing.
Also some col/row params were swapped as their order was confusing.
I'm also not sure about the use of global vars instead of passing them along with your method, but that I did not change (line 92/93).
Please note that I am not a Python programmer.
Cheers

